### PR TITLE
Version bump.

### DIFF
--- a/argo-ncg.spec
+++ b/argo-ncg.spec
@@ -5,7 +5,7 @@
 
 Summary: ARGO Nagios config generator
 Name: argo-ncg
-Version: 0.4.2
+Version: 0.4.3
 Release: 1%{?dist}
 License: ASL 2.0
 Group: Network/Monitoring


### PR DESCRIPTION
Implement certificate monitoring for EGI ops tools
Reconfigure nagios to deliver metric results to prod and devel caches
New version of Nagios raises warning for retry_check_interval
NCG on CentOS 7
Add new WMS probe
Monitor size of AMS publisher local cache.