### PR TITLE
Version 0.4.3

### DIFF
--- a/argo-ncg.spec
+++ b/argo-ncg.spec
@@ -5,7 +5,7 @@
 
 Summary: ARGO Nagios config generator
 Name: argo-ncg
-Version: 0.4.2
+Version: 0.4.3
 Release: 1%{?dist}
 License: ASL 2.0
 Group: Network/Monitoring

--- a/config/ncg-metric-config.d/cloudmon.conf
+++ b/config/ncg-metric-config.d/cloudmon.conf
@@ -208,6 +208,34 @@
       },
       "probe" : "novaprobe.py"
    },
+   "eu.egi.cloud.OpenStack-VM-OIDC" : {
+      "attribute" : {
+         "OIDC_ACCESS_TOKEN" : "--access-token",
+         "OS_KEYSTONE_URL" : "--endpoint",
+         "OS_RESOURCE" : "--flavor",
+         "OS_IMAGE" : "--image"
+      },
+      "docurl" : "https://wiki.egi.eu/wiki/Cloud_SAM_tests",
+      "parameter" : {
+         "--capath" : "/etc/grid-security/certificates/"
+      },
+      "dependency" : {
+         "hr.srce.GridProxy-Valid" : 0,
+         "org.nagios.Keystone-TCP": 1
+      },
+      "flags" : {
+         "OBSESS" : 1,
+         "NOHOSTNAME" : 1
+      },
+      "config" : {
+         "maxCheckAttempts" : 2,
+         "timeout" : 300,
+         "path" : "/usr/libexec/argo-monitoring/probes/fedcloud",
+         "interval" : 60,
+         "retryInterval" : 15
+      },
+      "probe" : "novaprobe.py"
+   },
    "eu.egi.Keystone-IGTF" : {
       "flags" : {
          "OBSESS" : 1,

--- a/config/ncg-metric-config.d/midmon.conf
+++ b/config/ncg-metric-config.d/midmon.conf
@@ -391,6 +391,25 @@
          "interval" : 1440
       },
       "probe" : "midmon/check_bdii_entries_num"
+   },
+   "eu.egi.sec.WMS" : {
+      "parameter" : {
+         "2" : 0
+      },
+      "flags" : {
+         "NOHOSTNAME" : 1,
+         "NOTIMEOUT" : 1,
+         "OBSESS" :1
+      },
+      "docurl" : "https://wiki.egi.eu/wiki/MW_Nagios_tests",
+      "config" : {
+         "maxCheckAttempts" : 1,
+         "timeout" : 10,
+         "path" : "$USER1$",
+         "retryInterval" : 15,
+         "interval" : 1440
+      },
+      "probe" : "check_dummy"
    }
 }
 

--- a/config/ncg-metric-config.d/nagios.conf
+++ b/config/ncg-metric-config.d/nagios.conf
@@ -6,7 +6,7 @@
       },
       "parameter" : {
          "-C" : "30,7",
-         "--sni" : "",
+         "--sni" : ""
       },
       "config" : {
          "interval" : 240,

--- a/config/ncg-metric-config.d/nagios.conf
+++ b/config/ncg-metric-config.d/nagios.conf
@@ -1,0 +1,24 @@
+{
+   "org.nagios.CertLifetime" : {
+      "attribute" : {
+         "NAGIOS_HOST_CERT" : "-J",
+         "NAGIOS_HOST_KEY" : "-K"
+      },
+      "parameter" : {
+         "-C" : "30,7",
+         "--sni" : "",
+      },
+      "config" : {
+         "interval" : 240,
+         "maxCheckAttempts" : 2,
+         "path" : "$USER1$",
+         "retryInterval" : 30,
+         "timeout" : 60
+      },
+      "docurl" : "https://wiki.egi.eu/wiki/ROC_SAM_Tests#org.nagios.CertLifetime",
+      "flags" : {
+         "OBSESS" : 1
+      },
+      "probe" : "check_http"
+   }
+}

--- a/config/ncg-metric-config.d/nagios.conf
+++ b/config/ncg-metric-config.d/nagios.conf
@@ -5,7 +5,7 @@
          "NAGIOS_HOST_KEY" : "-K"
       },
       "parameter" : {
-         "-C" : "30,7",
+         "-C" : "30",
          "--sni" : ""
       },
       "config" : {

--- a/config/templates/commands.template
+++ b/config/templates/commands.template
@@ -102,7 +102,7 @@ define command{
 
 define command {
         command_name handle_service_check
-        command_line /usr/libexec/argo-msg-nagios/handle_service_check  --role=<NAGIOS_ROLE> --tenant=<TENANT> --send-to-msg=<SEND_TO_MSG> && /usr/bin/ams-metric-to-queue --queue /var/spool/argo-nagios-ams-publisher/metrics/ --service "$_SERVICESERVICE_FLAVOUR$" --hostname "$HOSTNAME$" --metric "$_SERVICEMETRIC_NAME$" --status "$SERVICESTATE$" --summary "$SERVICEOUTPUT$" --message "$LONGSERVICEOUTPUT$" --vofqan "$_SERVICEVO_FQAN$" --voname "$_SERVICEVO$" --roc "$_SERVICEROC$" --servicestatetype "$SERVICESTATETYPE$"
+        command_line /usr/libexec/argo-msg-nagios/handle_service_check  --role=<NAGIOS_ROLE> --tenant=<TENANT> --send-to-msg=<SEND_TO_MSG> && /usr/bin/ams-metric-to-queue --queue /var/spool/argo-nagios-ams-publisher/metrics/ /var/spool/argo-nagios-ams-publisher/metricsdevel/ --service "$_SERVICESERVICE_FLAVOUR$" --hostname "$HOSTNAME$" --metric "$_SERVICEMETRIC_NAME$" --status "$SERVICESTATE$" --summary "$SERVICEOUTPUT$" --message "$LONGSERVICEOUTPUT$" --vofqan "$_SERVICEVO_FQAN$" --voname "$_SERVICEVO$" --roc "$_SERVICEROC$" --servicestatetype "$SERVICESTATETYPE$"
 }
 
 define command {

--- a/config/templates/services.template
+++ b/config/templates/services.template
@@ -25,7 +25,7 @@ define service{
         active_checks_enabled           0
         passive_checks_enabled          1
         check_interval                  120
-        retry_interval            120
+        retry_interval                  120
         max_check_attempts              1
         register                        0
         obsess_over_service             0

--- a/config/templates/services.template
+++ b/config/templates/services.template
@@ -25,7 +25,7 @@ define service{
         active_checks_enabled           0
         passive_checks_enabled          1
         check_interval                  120
-        retry_check_interval            120
+        retry_interval            120
         max_check_attempts              1
         register                        0
         obsess_over_service             0

--- a/config/templates/services/native.template
+++ b/config/templates/services/native.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  <contactlist>
         check_command                   <commandName>!<path>/<probe>!<timeout>!<options>
         check_interval                  <interval>
-        retry_check_interval            <retryInterval>
+        retry_interval            <retryInterval>
         max_check_attempts              <maxCheckAttempts>
         obsess_over_service             <obsess>
         <customVars>

--- a/config/templates/services/native.template
+++ b/config/templates/services/native.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  <contactlist>
         check_command                   <commandName>!<path>/<probe>!<timeout>!<options>
         check_interval                  <interval>
-        retry_interval            <retryInterval>
+        retry_interval                  <retryInterval>
         max_check_attempts              <maxCheckAttempts>
         obsess_over_service             <obsess>
         <customVars>

--- a/config/templates/services/wlcg.nrpe.template
+++ b/config/templates/services/wlcg.nrpe.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  <contactlist>
         check_command                   ncg_check_nrpe_service!<NRPE_UI>!<nrpecommand>!<timeout>
         check_interval                  <interval>
-        retry_check_interval            <retryInterval>
+        retry_interval            <retryInterval>
         max_check_attempts              <maxCheckAttempts>
         obsess_over_service             <obsess>
         <customVars>

--- a/config/templates/services/wlcg.nrpe.template
+++ b/config/templates/services/wlcg.nrpe.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  <contactlist>
         check_command                   ncg_check_nrpe_service!<NRPE_UI>!<nrpecommand>!<timeout>
         check_interval                  <interval>
-        retry_interval            <retryInterval>
+        retry_interval                  <retryInterval>
         max_check_attempts              <maxCheckAttempts>
         obsess_over_service             <obsess>
         <customVars>

--- a/config/templates/services/wlcg.passive.template
+++ b/config/templates/services/wlcg.passive.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  <contactlist>
         check_command                   ncg_check_passive!This metric is part of <parent> bundle and cannot be executed independently.
         check_interval                  <interval>
-        retry_interval            <retryInterval>
+        retry_interval                  <retryInterval>
         max_check_attempts              <maxCheckAttempts>
         obsess_over_service             <obsess>
         <customVars>        

--- a/config/templates/services/wlcg.passive.template
+++ b/config/templates/services/wlcg.passive.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  <contactlist>
         check_command                   ncg_check_passive!This metric is part of <parent> bundle and cannot be executed independently.
         check_interval                  <interval>
-        retry_check_interval            <retryInterval>
+        retry_interval            <retryInterval>
         max_check_attempts              <maxCheckAttempts>
         obsess_over_service             <obsess>
         <customVars>        

--- a/config/templates/wlcg.nagios/nrpe.template
+++ b/config/templates/wlcg.nagios/nrpe.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  nagios-site
         check_command                   ncg_check_native_noargs!$USER1$/check_nrpe!10
         check_interval                  10
-        retry_check_interval            2
+        retry_interval            2
         max_check_attempts              4
         obsess_over_service             0
 }
@@ -19,7 +19,7 @@ define service{
         contact_groups                  nagios-site
         check_command                   ncg_check_nrpe_service!<NRPE_UI>!check_push_nrpe!120
         check_interval                  30
-        retry_check_interval            5
+        retry_interval            5
         max_check_attempts              4
         obsess_over_service             0
         action_url                      /nagios/html/pnp4nagios/index.php?host=$HOSTNAME$&srv=$SERVICEDESC$        

--- a/config/templates/wlcg.nagios/nrpe.template
+++ b/config/templates/wlcg.nagios/nrpe.template
@@ -6,7 +6,7 @@ define service{
         contact_groups                  nagios-site
         check_command                   ncg_check_native_noargs!$USER1$/check_nrpe!10
         check_interval                  10
-        retry_interval            2
+        retry_interval                  2
         max_check_attempts              4
         obsess_over_service             0
 }
@@ -19,7 +19,7 @@ define service{
         contact_groups                  nagios-site
         check_command                   ncg_check_nrpe_service!<NRPE_UI>!check_push_nrpe!120
         check_interval                  30
-        retry_interval            5
+        retry_interval                  5
         max_check_attempts              4
         obsess_over_service             0
         action_url                      /nagios/html/pnp4nagios/index.php?host=$HOSTNAME$&srv=$SERVICEDESC$        

--- a/src/modules/NCG/LocalMetrics/Hash.pm
+++ b/src/modules/NCG/LocalMetrics/Hash.pm
@@ -426,6 +426,19 @@ $WLCG_SERVICE->{'org.nagios.MsgDirSize'}->{parameter}->{'-w'} = '10000';
 $WLCG_SERVICE->{'org.nagios.MsgDirSize'}->{parameter}->{'-c'} = '100000';
 $WLCG_SERVICE->{'org.nagios.MsgDirSize'}->{parameter}->{'-f'} = '';
 
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{probe} = "check_dirsize.sh";
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{config}->{timeout} = 15;
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{config}->{interval} = 60;
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{config}->{retryInterval} = 5;
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{config}->{maxCheckAttempts} = 3;
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{config}->{path} = '/usr/libexec/argo-monitoring/probes/nagiosexchange';
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{flags}->{NOHOSTNAME} = 1;
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{flags}->{PNP} = 1;
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{parameter}->{'-d'} = '/var/spool/argo-nagios-ams-publisher';
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{parameter}->{'-w'} = '10000';
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{parameter}->{'-c'} = '100000';
+$WLCG_SERVICE->{'org.nagios.AmsDirSize'}->{parameter}->{'-f'} = '';
+
 $WLCG_SERVICE->{'org.nagios.ProcessMsgToHandler'}->{probe} = 'check_procs';
 $WLCG_SERVICE->{'org.nagios.ProcessMsgToHandler'}->{config}->{path} = $NCG::NCG_PROBES_PATH_NAGIOS;
 $WLCG_SERVICE->{'org.nagios.ProcessMsgToHandler'}->{config}->{interval} = 15;
@@ -578,6 +591,7 @@ $WLCG_NODETYPE->{internal}->{"NAGIOS"} = [
 'org.egee.RecvFromQueue', # (if INCLUDE_MSG_CHECKS_RECV
 #'org.egee.CheckConfig', # (if INCLUDE_MSG_CHECKS_RECV
 'org.nagios.MsgDirSize', # (if INCLUDE_MSG_CHECKS_RECV || INCLUDE_MSG_SEND_CHECKS
+'org.nagios.AmsDirSize', # (if INCLUDE_MSG_CHECKS_RECV || INCLUDE_MSG_SEND_CHECKS
 'org.nagios.ProcessMsgToHandler', # (if INCLUDE_MSG_CHECKS_RECV
 'org.nagios.MsgToHandlerPidFile', # (if INCLUDE_MSG_CHECKS_RECV
 'hr.srce.GoodCEs',

--- a/src/modules/NCG/LocalMetrics/POEM.pm
+++ b/src/modules/NCG/LocalMetrics/POEM.pm
@@ -57,7 +57,7 @@ sub getDataWWW {
     my $self = shift;
     my $url;
 
-    my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1);
+    my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1, ssl_opts => { SSL_ca_path => '/etc/grid-security/certificates' });
     $ua->agent("NCG::LocalMetrics::POEM");
     $url = $self->{POEM_ROOT_URL} . $DEFAULT_POEM_ROOT_URL_SUFFIX;
     my $req = HTTP::Request->new(GET => $url);

--- a/src/modules/NCG/LocalMetricsAttrs/Active.pm
+++ b/src/modules/NCG/LocalMetricsAttrs/Active.pm
@@ -130,6 +130,7 @@ sub _analyzeNAGIOS {
             $self->{SITEDB}->removeMetric($hostname, undef, "org.nagios.ProcessMsgToHandler");
             $self->{SITEDB}->removeMetric($hostname, undef, "org.nagios.MsgToHandlerPidFile");
             $self->{SITEDB}->removeMetric($hostname, undef, "org.nagios.MsgDirSize") if (!$self->{INCLUDE_MSG_CHECKS_SEND});
+            $self->{SITEDB}->removeMetric($hostname, undef, "org.nagios.AmsDirSize") if (!$self->{INCLUDE_MSG_CHECKS_SEND});
         }
         $self->{SITEDB}->removeMetric($hostname, undef, "org.egee.SendToMsg") if (!$self->{INCLUDE_MSG_CHECKS_SEND});
         # local metrics

--- a/src/modules/NCG/SiteContacts/GOCDB.pm
+++ b/src/modules/NCG/SiteContacts/GOCDB.pm
@@ -125,7 +125,7 @@ sub getData {
     $ENV{HTTPS_CERT_FILE} = $self->{X509_CERT};
     $ENV{HTTPS_CA_DIR} = '/etc/grid-security/certificates';
 
-    my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy => 1, ssl_opts => { SSL_key_file => $self->{X509_KEY}, SSL_cert_file => $self->{X509_CERT} });
+    my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy => 1, ssl_opts => { SSL_key_file => $self->{X509_KEY}, SSL_cert_file => $self->{X509_CERT}, SSL_ca_path => '/etc/grid-security/certificates' });
     $ua->agent('NCG::SiteContacts::GOCDB');
 
     my $url = $self->{GOCDB_ROOT_URL} . $self->{GOCDB_GET_METHOD};

--- a/src/modules/NCG/SiteInfo/GOCDB.pm
+++ b/src/modules/NCG/SiteInfo/GOCDB.pm
@@ -73,7 +73,7 @@ sub getData {
         $content = <$fileHndl>;
         close $fileHndl;
     } else {
-        my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1);
+        my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1, ssl_opts => { SSL_ca_path => '/etc/grid-security/certificates' });
         $ua->agent("NCG::SiteInfo::GOCDB");
 
         my $url;

--- a/src/modules/NCG/SiteSet/GOCDB.pm
+++ b/src/modules/NCG/SiteSet/GOCDB.pm
@@ -84,7 +84,7 @@ sub getData
         $content = <$fileHndl>;
         close $fileHndl;
     } else {
-        my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1);
+        my $ua = LWP::UserAgent->new(timeout=>$self->{TIMEOUT}, env_proxy=>1, ssl_opts => { SSL_ca_path => '/etc/grid-security/certificates' });
         $ua->agent("NCG::SiteSet::GOCDB");
 
         my $url;

--- a/src/ncg.reload.sh
+++ b/src/ncg.reload.sh
@@ -21,7 +21,7 @@ revert_config_and_exit () {
 }
 
 # check if nagios is running at all
-/sbin/service nagios status 2>&1 > /dev/null
+service nagios status 2>&1 > /dev/null
 # status will return 1 if not running
 if [ $? -ne 0 ]; then
     NAGIOS_RUNNING=0


### PR DESCRIPTION
ARGO-NCG Version dumb to 0.4.3

Implement certificate monitoring for EGI ops tools
Reconfigure nagios to deliver metric results to prod and devel caches
New version of Nagios raises warning for retry_check_interval
NCG on CentOS 7
Add new WMS probe
Monitor size of AMS publisher local cache.