### PR TITLE
Version bump.

### DIFF
--- a/argo-ncg.spec
+++ b/argo-ncg.spec
@@ -5,7 +5,7 @@
 
 Summary: ARGO Nagios config generator
 Name: argo-ncg
-Version: 0.4.5
+Version: 0.4.6
 Release: 1%{?dist}
 License: ASL 2.0
 Group: Network/Monitoring


### PR DESCRIPTION
ARGO-1728 Change default SRM port
ARGO-1729 NCG breaks on empty extension value
ARGO-1690 Remove old JSON metric configuration from argo-ncg
ARGO-1689 Remove POEM FQAN support from argo-ncg
ARGO-1577 Refactor monitoring engine to use token protected POEM API