### PR TITLE
Version bump.

### DIFF
--- a/argo-ncg.spec
+++ b/argo-ncg.spec
@@ -5,7 +5,7 @@
 
 Summary: ARGO Nagios config generator
 Name: argo-ncg
-Version: 0.4.6
+Version: 0.4.7
 Release: 1%{?dist}
 License: ASL 2.0
 Group: Network/Monitoring


### PR DESCRIPTION
OCSP Nagios call should pass site name in metric result