### PR TITLE
DEVOPS-85 remove workspace at the end of the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,4 +44,9 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            cleanWs()
+        }
+    }
 }


### PR DESCRIPTION
A pre existing tar was causing build to fail by cleaning up after each build we ensure this problem will not come up again