### PR TITLE
ARGO-2422 Move common parameters to separate config file

### DIFF
--- a/argo-ncg.spec
+++ b/argo-ncg.spec
@@ -46,6 +46,7 @@ install --mode=755 argo-java-truststore.sh $RPM_BUILD_ROOT/usr/libexec/%{name}
 install --directory $RPM_BUILD_ROOT%{configdir}/ncg.conf.d/
 install --directory $RPM_BUILD_ROOT%{configdir}/ncg-localdb.d/
 install ncg.conf $RPM_BUILD_ROOT%{configdir}
+install ncg-vars.conf $RPM_BUILD_ROOT%{configdir}
 install ncg.localdb $RPM_BUILD_ROOT%{configdir}
 install ncg.localdb.example $RPM_BUILD_ROOT%{configdir}
 install check_logfiles_ncg.conf $RPM_BUILD_ROOT%{configdir}
@@ -71,6 +72,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %config(noreplace) %{configdir}/ncg.conf.d
 %config(noreplace) %{configdir}/ncg.conf
+%config(noreplace) %{configdir}/ncg-vars.conf
 %config(noreplace) %{configdir}/ncg.localdb
 %config(noreplace) %{configdir}/ncg.localdb.example
 %config(noreplace) %{configdir}/ncg-localdb.d

--- a/config/ncg-vars.conf
+++ b/config/ncg-vars.conf
@@ -1,0 +1,35 @@
+# Set ARGO Monitoring Engine hostname
+# (default: hostname)
+# NAGIOS_SERVER = 
+
+# Set following option if you wish to receive
+# email alerts for Nagios internal checks
+# (default: root@localhost)
+# NAGIOS_ADMIN = root@localhost
+
+# ARGO WEB-API root URL
+# (default: https://api.argo.grnet.gr)
+# WEBAPI_ROOT_URL = https://api.argo.grnet.gr
+
+# ARGO WEB-API token must be provided
+# in order to fetch metric profiles
+# (default: )
+# WEBAPI_TOKEN = MY_WEBAPI_TOKEN
+
+# List of metric profiles used for configuring
+# ARGO Monitoring Engine
+# (default: )
+# PROFILES = MON 
+
+# ARGO POEM URL
+# (default: https://poem.egi.eu)
+# POEM_ROOT_URL = https://poem.egi.eu
+
+# ARGO POEM token must be provided in order 
+# to fetch metric definitions
+# (default: )
+# POEM_TOKEN = MY_POEM_TOKEN
+
+# GOCDB API root URL
+# (default: https://gocdb.egi.eu/gocdbpi)
+# GOCDB_ROOT_URL = https://gocdb.egi.eu/gocdbpi

--- a/config/ncg-vars.conf
+++ b/config/ncg-vars.conf
@@ -22,8 +22,8 @@
 # PROFILES = MON 
 
 # ARGO POEM URL
-# (default: https://poem.egi.eu)
-# POEM_ROOT_URL = https://poem.egi.eu
+# (default: https://training.poem.devel.argo.grnet.gr)
+# POEM_ROOT_URL = https://training.poem.devel.argo.grnet.gr
 
 # ARGO POEM token must be provided in order 
 # to fetch metric definitions

--- a/config/ncg.conf
+++ b/config/ncg.conf
@@ -3,62 +3,26 @@
 # For further details see:
 #   http://search.cpan.org/dist/Config-General/
 
-# Global variables which can be used in module
-# configuration (e.g. LDAP_ADDRESS=$BDII).
-# Variables in curly brackets are environment
-# variables.
-
-# Set following option if you wish to receive
-# email alerts for Nagios internal checks
-# default root@localhost
-# NAGIOS_ADMIN=admins@email.com
-
-# list of VOs for which you wish to run checks
-VO = dteam
-
-#
-# Some optional config
-#
-# NAGIOS_SERVER = nagios.fqdn
-# MYPROXY_SERVER = myproxy.fqdn
+# include standard variables
+include ncg-vars.conf
 
 # Configuration of individual NCG modules.
 # First level block represents abstract module.
-
-<NCG::ConfigGen>
-
-  # Second level block defines specific module
-  # parameters passed at invocation.
-
-  <Nagios>
-    NAGIOS_ROLE = ngi
-    INCLUDE_EMPTY_HOSTS = 0
-    ENABLE_NOTIFICATIONS = 0
-    SEND_TO_DASHBOARD = 0
-    CHECK_HOSTS = 0
-    TENANT = ARGO-TEST
-    ROBOT_CERT=/etc/nagios/globus/robocert.pem
-    ROBOT_KEY=/etc/nagios/globus/robokey.pem
-    USE_ROBOT_CERT=1
-    SEND_TO_MSG = 0
-  </Nagios>
-
-</NCG::ConfigGen>
-
-# NCG modules for gathering site information
 <NCG::SiteSet>
   <GOCDB>
-    GOCDB_ROOT_URL=https://goc.egi.eu/gocdbpi
-    ROC=NGI_HR
+    GOCDB_ROOT_URL=$GOCDB_ROOT_URL
+    SCOPE=$GOCDB_SCOPE
   </GOCDB>
   <File>
-      DB_FILE=/etc/argo-ncg/ncg.localdb
-      DB_DIRECTORY=/etc/argo-ncg/ncg-localdb.d
+    DB_FILE=/etc/argo-ncg/ncg.localdb
+    DB_DIRECTORY=/etc/argo-ncg/ncg-localdb.d
   </File>
 </NCG::SiteSet>
+
 <NCG::SiteInfo>
   <GOCDB>
-    GOCDB_ROOT_URL=https://goc.egi.eu/gocdbpi
+    GOCDB_ROOT_URL=$GOCDB_ROOT_URL
+    SCOPE=$GOCDB_SCOPE
   </GOCDB>
   <File>
     DB_FILE=/etc/argo-ncg/ncg.localdb
@@ -66,40 +30,36 @@ VO = dteam
   </File>
 </NCG::SiteInfo>
 
-# NCG modules for gathering metrics & attributes
 <NCG::LocalMetrics>
   <WEBAPI>
-    WEBAPI_ROOT_URL = https://api.devel.argo.grnet.gr
-    PROFILES = ARGO_TEST,ARGO_MON,MW_MONITOR,OPS_MONITOR
-    TOKEN = TOKEN_STRING
+    WEBAPI_ROOT_URL = $WEBAPI_ROOT_URL
+    PROFILES = $PROFILES
+    TOKEN = $WEBAPI_TOKEN
   </WEBAPI>
   <File>
     DB_FILE=/etc/argo-ncg/ncg.localdb
     DB_DIRECTORY=/etc/argo-ncg/ncg-localdb.d
   </File>
 </NCG::LocalMetrics>
+
 <NCG::MetricConfig>
   <POEM>
-    POEM_ROOT_URL = http://egi.poem.devel.argo.grnet.gr
-    TOKEN = POEM_TOKEN_STRING
+    POEM_ROOT_URL = $POEM_ROOT_URL
+    TOKEN = $POEM_TOKEN
   </POEM>
 </NCG::MetricConfig>
+
 <NCG::LocalMetricsAttrs>
-  <Active>
-    GOCDB_ROOT_URL=https://goc.egi.eu/gocdbpi
-    BDII_HOST=bdii.fqdn
-    INCLUDE_PROXY_CHECKS = 1
-    INCLUDE_MSG_CHECKS_SEND = 0
-  </Active>
-  <LDAP>
-    LDAP_ADDRESS=bdii.fqdn
-    BDII_LEVEL=top
-  </LDAP>
+  <Active/>
   <File>
     DB_FILE=/etc/argo-ncg/ncg.localdb
     DB_DIRECTORY=/etc/argo-ncg/ncg-localdb.d
   </File>
 </NCG::LocalMetricsAttrs>
 
-# Include any custom configuration.
+<NCG::ConfigGen>
+  <Nagios/>
+</NCG::ConfigGen>
+
+# include custom configurations
 include ncg.conf.d/*.conf

--- a/src/modules/NCG/MetricConfig/POEM.pm
+++ b/src/modules/NCG/MetricConfig/POEM.pm
@@ -26,7 +26,7 @@ use LWP::UserAgent;
 
 @ISA=("NCG::MetricConfig");
 
-my $DEFAULT_POEM_ROOT_URL = "http://poem.egi.eu";
+my $DEFAULT_POEM_ROOT_URL = "https://training.poem.devel.argo.grnet.gr";
 my $DEFAULT_POEM_ROOT_URL_SUFFIX = "/api/v2/metrics";
 sub new
 {
@@ -153,7 +153,7 @@ reference that can contain following elements:
     (default: )
     
     POEM_ROOT_URL - POEM JSON API root URL
-    (default: http://localhost/poem_sync)
+    (default: https://training.poem.devel.argo.grnet.gr)
 
     METRIC_CONFIG - metric configuration structure fetched from
     NCG::MetricConfig module


### PR DESCRIPTION
Idea is to make ncg.conf as generic as possible and move common variables to separate file.