### PR TITLE
Version bump.

### DIFF
--- a/argo-ncg.spec
+++ b/argo-ncg.spec
@@ -5,7 +5,7 @@
 
 Summary: ARGO Nagios config generator
 Name: argo-ncg
-Version: 0.4.10
+Version: 0.4.11
 Release: 1%{?dist}
 License: ASL 2.0
 Group: Network/Monitoring
@@ -95,6 +95,8 @@ if [ -f /etc/init.d/ncg ] ; then
 fi
 
 %changelog
+* Fri May 8 2020 Emir Imamagic <eimamagi@srce.hr - 0.4.11-1
+- Version bump
 * Fri Apr 10 2020 Emir Imamagic <eimamagi@srce.hr> - 0.4.10-1
 - Version bump
 * Thu Mar 26 2020 Emir Imamagic <eimamagi@srce.hr> - 0.4.9-1


### PR DESCRIPTION
ARGO-2422 Move common parameters to separate config file
ARGO-2423 Use standard OS CA bundle
ARGO-2407 Change OBSESS flag logic
ARGO-2344 Remove file parameters & attributes
ARGO-2410 Remove UNICORE specific code
ARGO-2409 Add generic PORT, SSL and PATH attributes
ARGO-2401 Set GOCDB URL attribute
ARGO-2425 Set default VO to ops (affects only instances using VO credentials)